### PR TITLE
Update inclusion paths to last version of Arm TF-A

### DIFF
--- a/ble.mk
+++ b/ble.mk
@@ -18,8 +18,8 @@ PLAT_INCLUDES		+= 	-I$(MV_DDR_PATH) \
 				-I$(CURDIR)/include/ \
 				-I$(CURDIR)/include/drivers \
 				-I$(CURDIR)/include/lib \
-				-I$(CURDIR)/include/lib/stdlib \
-				-I$(CURDIR)/include/lib/stdlib/sys \
+				-I$(CURDIR)/include/lib/libc \
+				-I$(CURDIR)/include/lib/libc/sys \
 				-I$(CURDIR)/drivers/marvell
 
 BLE_LINKERFILE		:=	$(BLE_PATH)/ble.ld.S


### PR DESCRIPTION
After the commit 61f72a34 in the TF-A repository the
new inclusion path must be include/lib/libc instead
of include/lib/stdlib.